### PR TITLE
Fix track height in IE

### DIFF
--- a/_inputrange.scss
+++ b/_inputrange.scss
@@ -91,7 +91,7 @@ $contrast: 5% !default;
     @include track();
     background: transparent;
     border-color: transparent;
-    border-width: $thumb-width 0;
+    border-width: ($thumb-height / 2) 0;
     color: transparent;
   }
 


### PR DESCRIPTION
In IE the inspector's layout for a styled range slider shows it takes up a bigger height than in other browsers. This is because the top & bottom border the track are using the thumb's full width, when I think it should only be using half of the thumb's height