### PR TITLE
Conver sass math to css calc

### DIFF
--- a/_inputrange.scss
+++ b/_inputrange.scss
@@ -9,6 +9,9 @@
 $track-color: #eceff1 !default;
 $thumb-color: #607d8b !default;
 
+$progress-color: transparent !default; // can be a CSS custom prop: var(--progress-color, transparent)
+$progress-value: 0% !default; // 0-100%. ideally, a dynamic CSS custom prop
+
 $thumb-radius: 12px !default;
 $thumb-height: 24px !default;
 $thumb-width: 24px !default;
@@ -33,6 +36,13 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
 
 @mixin shadow($shadow-size, $shadow-blur, $shadow-color) {
   box-shadow: $shadow-size $shadow-size $shadow-blur $shadow-color, 0 0 $shadow-size lighten($shadow-color, 5%);
+}
+
+@mixin progress-bar {
+  background-image: linear-gradient(to right,
+      $progress-color $progress-value,
+      transparent 0%,
+      transparent 100%);
 }
 
 @mixin track {
@@ -83,6 +93,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
     @include track;
     @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
     background-color: $track-color;
+    @include progress-bar;
     border: $track-border-width solid $track-border-color;
     border-radius: $track-radius;
   }
@@ -97,6 +108,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
     @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
     @include track;
     background-color: $track-color;
+    @include progress-bar;
     border: $track-border-width solid $track-border-color;
     border-radius: $track-radius;
     height: math.div($track-height, 2);
@@ -124,6 +136,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
   &::-ms-fill-upper {
     @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
     background-color: $track-color;
+    @include progress-bar;
     border: $track-border-width solid $track-border-color;
     border-radius: ($track-radius * 2);
   }
@@ -134,6 +147,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
   }
 
   &:disabled {
+
     &::-webkit-slider-thumb,
     &::-moz-range-thumb,
     &::-ms-thumb,

--- a/_inputrange.scss
+++ b/_inputrange.scss
@@ -4,8 +4,6 @@
 // Version 1.5.3
 // MIT License
 
-@use 'sass:math';
-
 $track-color: #eceff1 !default;
 $thumb-color: #607d8b !default;
 
@@ -79,7 +77,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
 [type='range'] {
   -webkit-appearance: none;
   background-color: transparent;
-  margin: math.div($thumb-height, 2) 0;
+  margin: calc(#{$thumb-height} / 2) 0;
   width: $track-width;
 
   &::-moz-focus-outer {
@@ -114,7 +112,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
   &::-webkit-slider-thumb {
     @include thumb;
     -webkit-appearance: none;
-    margin-top: (math.div((-$track-border-width * 2 + $track-height), 2) - math.div($thumb-height, 2));
+    margin-top: calc(((-#{$track-border-width} * 2 + #{$track-height}) / 2) - (#{$thumb-height} / 2));
   }
 
   &::-moz-range-track {
@@ -124,7 +122,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
     @include progress-bar;
     border: $track-border-width solid $track-border-color;
     border-radius: $track-radius;
-    height: math.div($track-height, 2);
+    height: calc(#{$track-height} / 2);
   }
 
   &::-moz-range-thumb {
@@ -135,7 +133,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
     @include track;
     background-color: transparent;
     border-color: transparent;
-    border-width: math.div($thumb-height, 2) 0;
+    border-width: calc(#{$thumb-height} / 2) 0;
     color: transparent;
   }
 
@@ -143,7 +141,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
     @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
     background-color: $ie-bottom-track-color;
     border: $track-border-width solid $track-border-color;
-    border-radius: ($track-radius * 2);
+    border-radius: calc(#{$track-radius} * 2);
   }
 
   &::-ms-fill-upper {
@@ -151,12 +149,12 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
     background-color: $track-color;
     @include progress-bar;
     border: $track-border-width solid $track-border-color;
-    border-radius: ($track-radius * 2);
+    border-radius: calc(#{$track-radius} * 2);
   }
 
   &::-ms-thumb {
     @include thumb;
-    margin-top: math.div($track-height, 4);
+    margin-top: calc(#{$track-height} / 4);
   }
 
   &:disabled {

--- a/_inputrange.scss
+++ b/_inputrange.scss
@@ -21,6 +21,12 @@ $thumb-shadow-color: rgba(0, 0, 0, .2) !default;
 $thumb-border-width: 2px !default;
 $thumb-border-color: #eceff1 !default;
 
+$thumb-background: none !default;
+$thumb-background-size: contain !default;
+$thumb-background-position: center center !default;
+$thumb-background-repeat: no-repeat !default;
+$thumb-background-origin: border-box !default;
+
 $track-width: 100% !default;
 $track-height: 8px !default;
 $track-shadow-size: 1px !default;
@@ -54,7 +60,14 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
 
 @mixin thumb {
   @include shadow($thumb-shadow-size, $thumb-shadow-blur, $thumb-shadow-color);
+
+  background: $thumb-background;
+  background-size: $thumb-background-size;
+  background-position: $thumb-background-position;
+  background-repeat: $thumb-background-repeat;
+  background-origin: $thumb-background-origin;
   background-color: $thumb-color;
+
   border: $thumb-border-width solid $thumb-border-color;
   border-radius: $thumb-radius;
   box-sizing: border-box;

--- a/_inputrange.scss
+++ b/_inputrange.scss
@@ -44,7 +44,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
 
 @mixin thumb {
   @include shadow($thumb-shadow-size, $thumb-shadow-blur, $thumb-shadow-color);
-  background: $thumb-color;
+  background-color: $thumb-color;
   border: $thumb-border-width solid $thumb-border-color;
   border-radius: $thumb-radius;
   box-sizing: border-box;
@@ -55,7 +55,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
 
 [type='range'] {
   -webkit-appearance: none;
-  background: transparent;
+  background-color: transparent;
   margin: math.div($thumb-height, 2) 0;
   width: $track-width;
 
@@ -67,22 +67,22 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
     outline: 0;
 
     &::-webkit-slider-runnable-track {
-      background: lighten($track-color, $contrast);
+      background-color: lighten($track-color, $contrast);
     }
 
     &::-ms-fill-lower {
-      background: $track-color;
+      background-color: $track-color;
     }
 
     &::-ms-fill-upper {
-      background: lighten($track-color, $contrast);
+      background-color: lighten($track-color, $contrast);
     }
   }
 
   &::-webkit-slider-runnable-track {
     @include track;
     @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
-    background: $track-color;
+    background-color: $track-color;
     border: $track-border-width solid $track-border-color;
     border-radius: $track-radius;
   }
@@ -96,7 +96,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
   &::-moz-range-track {
     @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
     @include track;
-    background: $track-color;
+    background-color: $track-color;
     border: $track-border-width solid $track-border-color;
     border-radius: $track-radius;
     height: math.div($track-height, 2);
@@ -108,7 +108,7 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
 
   &::-ms-track {
     @include track;
-    background: transparent;
+    background-color: transparent;
     border-color: transparent;
     border-width: math.div($thumb-height, 2) 0;
     color: transparent;
@@ -116,14 +116,14 @@ $ie-bottom-track-color: darken($track-color, $contrast) !default;
 
   &::-ms-fill-lower {
     @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
-    background: $ie-bottom-track-color;
+    background-color: $ie-bottom-track-color;
     border: $track-border-width solid $track-border-color;
     border-radius: ($track-radius * 2);
   }
 
   &::-ms-fill-upper {
     @include shadow($track-shadow-size, $track-shadow-blur, $track-shadow-color);
-    background: $track-color;
+    background-color: $track-color;
     border: $track-border-width solid $track-border-color;
     border-radius: ($track-radius * 2);
   }

--- a/example/index.html
+++ b/example/index.html
@@ -12,7 +12,14 @@
   </head>
   <body>
     <div>
-      <input type="range" />
+      <input type="range" max="100" style="--progress: 50%" oninput="updateProgress(this)" />
     </div>
   </body>
+
+  <script>
+    function updateProgress(range) {
+      console.log({range});
+      range.style.setProperty("--progress", `${100 * range.value / range.max}%`);
+    }
+  </script>
 </html>

--- a/example/inputrange.css
+++ b/example/inputrange.css
@@ -1,6 +1,6 @@
 [type=range] {
   -webkit-appearance: none;
-  background: transparent;
+  background-color: transparent;
   margin: 12px 0;
   width: 100%;
 }
@@ -11,13 +11,13 @@
   outline: 0;
 }
 [type=range]:focus::-webkit-slider-runnable-track {
-  background: #fbfbfc;
+  background-color: #fbfbfc;
 }
 [type=range]:focus::-ms-fill-lower {
-  background: #eceff1;
+  background-color: #eceff1;
 }
 [type=range]:focus::-ms-fill-upper {
-  background: #fbfbfc;
+  background-color: #fbfbfc;
 }
 [type=range]::-webkit-slider-runnable-track {
   cursor: default;
@@ -25,13 +25,19 @@
   transition: all 0.2s ease;
   width: 100%;
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2), 0 0 1px rgba(13, 13, 13, 0.2);
-  background: #eceff1;
+  background-color: #eceff1;
+  background-image: linear-gradient(to right, #ABE188 var(--progress), transparent 0%, transparent 100%);
   border: 2px solid #cfd8dc;
   border-radius: 5px;
 }
 [type=range]::-webkit-slider-thumb {
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2), 0 0 4px rgba(13, 13, 13, 0.2);
-  background: #607d8b;
+  background: none;
+  background-size: contain;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-origin: border-box;
+  background-color: #607d8b;
   border: 2px solid #eceff1;
   border-radius: 12px;
   box-sizing: border-box;
@@ -47,14 +53,20 @@
   height: 8px;
   transition: all 0.2s ease;
   width: 100%;
-  background: #eceff1;
+  background-color: #eceff1;
+  background-image: linear-gradient(to right, #ABE188 var(--progress), transparent 0%, transparent 100%);
   border: 2px solid #cfd8dc;
   border-radius: 5px;
   height: 4px;
 }
 [type=range]::-moz-range-thumb {
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2), 0 0 4px rgba(13, 13, 13, 0.2);
-  background: #607d8b;
+  background: none;
+  background-size: contain;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-origin: border-box;
+  background-color: #607d8b;
   border: 2px solid #eceff1;
   border-radius: 12px;
   box-sizing: border-box;
@@ -67,26 +79,32 @@
   height: 8px;
   transition: all 0.2s ease;
   width: 100%;
-  background: transparent;
+  background-color: transparent;
   border-color: transparent;
   border-width: 12px 0;
   color: transparent;
 }
 [type=range]::-ms-fill-lower {
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2), 0 0 1px rgba(13, 13, 13, 0.2);
-  background: #dde3e6;
+  background-color: #dde3e6;
   border: 2px solid #cfd8dc;
   border-radius: 10px;
 }
 [type=range]::-ms-fill-upper {
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2), 0 0 1px rgba(13, 13, 13, 0.2);
-  background: #eceff1;
+  background-color: #eceff1;
+  background-image: linear-gradient(to right, #ABE188 var(--progress), transparent 0%, transparent 100%);
   border: 2px solid #cfd8dc;
   border-radius: 10px;
 }
 [type=range]::-ms-thumb {
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2), 0 0 4px rgba(13, 13, 13, 0.2);
-  background: #607d8b;
+  background: none;
+  background-size: contain;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-origin: border-box;
+  background-color: #607d8b;
   border: 2px solid #eceff1;
   border-radius: 12px;
   box-sizing: border-box;
@@ -98,3 +116,5 @@
 [type=range]:disabled::-webkit-slider-thumb, [type=range]:disabled::-moz-range-thumb, [type=range]:disabled::-ms-thumb, [type=range]:disabled::-webkit-slider-runnable-track, [type=range]:disabled::-ms-fill-lower, [type=range]:disabled::-ms-fill-upper {
   cursor: not-allowed;
 }
+
+/*# sourceMappingURL=inputrange.css.map */

--- a/example/inputrange.css
+++ b/example/inputrange.css
@@ -1,7 +1,7 @@
 [type=range] {
   -webkit-appearance: none;
   background-color: transparent;
-  margin: 12px 0;
+  margin: calc(24px / 2) 0;
   width: 100%;
 }
 [type=range]::-moz-focus-outer {
@@ -26,7 +26,7 @@
   width: 100%;
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2), 0 0 1px rgba(13, 13, 13, 0.2);
   background-color: #eceff1;
-  background-image: linear-gradient(to right, #ABE188 var(--progress), transparent 0%, transparent 100%);
+  background-image: linear-gradient(to right, transparent 0%, transparent 0%, transparent 100%);
   border: 2px solid #cfd8dc;
   border-radius: 5px;
 }
@@ -45,7 +45,7 @@
   height: 24px;
   width: 24px;
   -webkit-appearance: none;
-  margin-top: -10px;
+  margin-top: calc((-2px * 2 + 8px) / 2 - (24px / 2));
 }
 [type=range]::-moz-range-track {
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2), 0 0 1px rgba(13, 13, 13, 0.2);
@@ -54,10 +54,10 @@
   transition: all 0.2s ease;
   width: 100%;
   background-color: #eceff1;
-  background-image: linear-gradient(to right, #ABE188 var(--progress), transparent 0%, transparent 100%);
+  background-image: linear-gradient(to right, transparent 0%, transparent 0%, transparent 100%);
   border: 2px solid #cfd8dc;
   border-radius: 5px;
-  height: 4px;
+  height: calc(8px / 2);
 }
 [type=range]::-moz-range-thumb {
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2), 0 0 4px rgba(13, 13, 13, 0.2);
@@ -81,21 +81,21 @@
   width: 100%;
   background-color: transparent;
   border-color: transparent;
-  border-width: 12px 0;
+  border-width: calc(24px / 2) 0;
   color: transparent;
 }
 [type=range]::-ms-fill-lower {
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2), 0 0 1px rgba(13, 13, 13, 0.2);
   background-color: #dde3e6;
   border: 2px solid #cfd8dc;
-  border-radius: 10px;
+  border-radius: calc(5px * 2);
 }
 [type=range]::-ms-fill-upper {
   box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2), 0 0 1px rgba(13, 13, 13, 0.2);
   background-color: #eceff1;
-  background-image: linear-gradient(to right, #ABE188 var(--progress), transparent 0%, transparent 100%);
+  background-image: linear-gradient(to right, transparent 0%, transparent 0%, transparent 100%);
   border: 2px solid #cfd8dc;
-  border-radius: 10px;
+  border-radius: calc(5px * 2);
 }
 [type=range]::-ms-thumb {
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2), 0 0 4px rgba(13, 13, 13, 0.2);
@@ -111,7 +111,7 @@
   cursor: default;
   height: 24px;
   width: 24px;
-  margin-top: 2px;
+  margin-top: calc(8px / 4);
 }
 [type=range]:disabled::-webkit-slider-thumb, [type=range]:disabled::-moz-range-thumb, [type=range]:disabled::-ms-thumb, [type=range]:disabled::-webkit-slider-runnable-track, [type=range]:disabled::-ms-fill-lower, [type=range]:disabled::-ms-fill-upper {
   cursor: not-allowed;


### PR DESCRIPTION
## What
Convert all sass math to css `calc()`

## Why
It allow us to pass css custom properties ( `--variable`) to all size related variables

```scss
$thumb-height: var(--thumb-size);
$track-shadow-size: var(--shadow-size);
```
what facilitates "state based" and responsive styling override

```scss
...

input[type="range"] {
    --thumb-size: 20px;
    --shadow-size: 3px;

    &:hover {
        --shadow-size: 6px;
    }

    @media(min-width: 470px) {
        --thumb-size: 26px;
    }
}
```


That's why i think it worth bring it up, at least for a discussion.

## Caviats
This approach may get errors with "unit less" zeros involved in calculations

```scss
$track-border-width: 0; // error "silently" breaks the range input
```

So it is mandatory to set some unit an zeroing a variable out
```scss
$track-border-width: 0px; // works 
```